### PR TITLE
Feature: Data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+.cache/
+.vscode/
 log/
 build_isolated/
-.cache/
 devel_isolated/
-.vscode/
 compile_commands.json
+result.csv


### PR DESCRIPTION
Closes #11.

We extract these 2 data:

- Total joint value change
- Planning time

Current implementation will aim at intercepting the Plan from MoveIt, compute the total change and time it took to plan, then pass the plan for execution.

In theory we can do all of that away from the main application code, but that requires multithreaded programming, and I don't want to spend extra time on that. Maybe we can have 2 version of unity_bridge though, one instrumented, one not to avoid overhead if instrumentation is not needed.

TODO:

- [x] Update target branch from `main` to `dev`
- [x] Implement the change