### PR TITLE
Switch from catkin_make to catkin_tools

### DIFF
--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -11,8 +11,8 @@ curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo ap
 # Update the repository information
 sudo apt-get update
 
-# Install Base ROS Noetic, rosdep, python is python3 system alias and jq for json concat
-sudo apt-get install -y ros-noetic-ros-base python3-rosdep g++ python-is-python3 jq
+# Install Base ROS Noetic, rosdep, python is python3 system alias, jq for json concat and catkin-tools
+sudo apt-get install -y ros-noetic-ros-base python3-rosdep g++ python-is-python3 jq python3-catkin-tools
 
 # Source ROS Environments
 source /opt/ros/noetic/setup.bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .cache/
 .vscode/
+.catkin_tools/
 log/
-build_isolated/
-devel_isolated/
+build/
+devel/
+logs/
 compile_commands.json
 result.csv

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-catkin_make_isolated -DCMAKE_EXPORT_COMPILE_COMMANDS=1 
-jq -s add build_isolated/**/compile_commands.json > compile_commands.json
+catkin build --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1 --
+jq -s add build/**/compile_commands.json > compile_commands.json


### PR DESCRIPTION
`python3-catkin-tools` provide catkin commands, which effectively function as `catkin_make_isolated`, but with:

- More user-friendly output
- Concurrent builds (`catkin_make_isolated` build each package one by one).