### PR TITLE
reduced distance between waypoints

### DIFF
--- a/src/ros_unity_bridge/src/unity_targets_listener.cpp
+++ b/src/ros_unity_bridge/src/unity_targets_listener.cpp
@@ -35,7 +35,7 @@ using GripperControl = ros_unity_messages::GripperControl;
 // ---
 
 static const int         PLANNING_ATTEMPTS = 5;
-static const double      TIME_PER_ATTEMPT = 10;
+static const double      TIME_PER_ATTEMPT = 30;
 static const std::string PLANNING_FRAME = "arm_base_link";
 static const std::string ARM_PLANNING_GROUP = "robot_arm";
 static const ros::Duration GRIPPER_CONTROL_DELAY = ros::Duration(1, 0);
@@ -453,7 +453,7 @@ void unity_targets_subs_handler(
 
     // Set execution mode (With/Without profiling)
     // [TODO]: Expose this as an option
-    auto planning_call = planning_no_profiling;
+    auto planning_call = planning_with_profiling;
     // Initialize maps
     for (const std::string joint_name : associated_joint_name) {
         total_joint_trajectory[joint_name] = 0;

--- a/src/ur10e_config/robot_moveit/config/ompl_planning.yaml
+++ b/src/ur10e_config/robot_moveit/config/ompl_planning.yaml
@@ -165,6 +165,7 @@ planner_configs:
     use_strict_queue_ordering: 0  # sort edges in the queue at the end of the batch (0) or after each rewiring (1). Default: 0
     find_approximate_solutions: 0  # track approximate solutions (1) or not (0). Default: 0
 robot_arm:
+  default_planner_config: PRM
   planner_configs:
     - AnytimePathShortening
     - SBL
@@ -193,6 +194,7 @@ robot_arm:
     - AITstar
     - ABITstar
     - BITstar
+  longest_valid_segment_fraction: 0.002
 robot_gripper:
   planner_configs:
     - AnytimePathShortening


### PR DESCRIPTION
Massively reduced the maximum distance between waypoints down to 0.002 (0.2% of workspace).

Moveit does not support continuous collision checking (CCD), path is collision free as long as all waypoints are collision-free. The previous value is way too big causing collision through small objects.

While the docs recommended 0.5% of workspace, in practice the clipping is still way too large to ignore. 0.001 is overkill, so we settled for 0.002.

Estimated average planning time would increase by 2-3 fold for non-optimizing planner, and probably more for optimizing planner.